### PR TITLE
Modernize command parameters for git add-on compatibility

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,6 +41,9 @@ jobs:
     - name: Run lizard integration tests
       run: |
         pytest test/test_lizard_integration.py -v
+    - name: Run date parameter tests
+      run: |
+        pytest test/test_date_parameters.py -v
     - name: Check formatting with black
       run: |
         # stop the build if the black formatter wants to change a file

--- a/README.md
+++ b/README.md
@@ -61,27 +61,46 @@ git-outlier --since="1 month ago" -l python javascript
 ### Command Options
 
 ```
-usage: git outlier [-h] [--languages LANGUAGES] [--metric METRIC] [--since SINCE] [--until UNTIL] [--top TOP] [-v] [path]
+usage: git_outlier.py [-h] [--languages <lang>] [--metric <type>]
+                      [--since <date>] [--until <date>] [--top <n>] [-v]
+                      [path]
 
 Find refactoring candidates by analyzing git history and code complexity.
 
 positional arguments:
-  path                  Path to git repository to analyze. Default: current directory
+  path                  Path to git repository to analyze. Default: current
+                        directory
 
 optional arguments:
   -h, --help            Show this help message and exit
-  --languages LANGUAGES, -l LANGUAGES
-                        Only analyze specified languages (can be repeated). Default: all supported languages. 
-                        Available: c, cpp, csharp, fortran, go, java, javascript, lua, objective-c, php, 
-                        python, ruby, rust, scala, swift, typescript
-  --metric METRIC, -m METRIC
-                        Complexity metric to use: CCN (cyclomatic complexity) or NLOC (lines of code). Default: CCN
-  --since SINCE         Show commits more recent than specific date. 
-                        Accepts: '2023-01-01', '6 months ago', 'last week'. Default: 12 months ago
-  --until UNTIL         Show commits older than specific date. 
-                        Accepts: '2023-12-31', '1 month ago', 'yesterday'. Default: today
-  --top TOP, -t TOP     Limit output to top N outliers per category. Default: 10
+  --languages <lang>, -l <lang>
+                        Only analyze specified languages (can be repeated).
+                        Default: all supported languages. Available: c, cpp,
+                        csharp, fortran, go, java, javascript, lua,
+                        objective-c, php, python, ruby, rust, scala, swift,
+                        typescript
+  --metric <type>, -m <type>
+                        Complexity metric to use: CCN (cyclomatic complexity)
+                        or NLOC (lines of code). Default: CCN
+  --since <date>        Show commits more recent than specific date. Accepts:
+                        '2023-01-01', '6 months ago', 'last week'. Default: 12
+                        months ago
+  --until <date>        Show commits older than specific date. Accepts:
+                        '2023-12-31', '1 month ago', 'yesterday'. Default:
+                        today
+  --top <n>, -t <n>     Limit output to top N outliers per category. Default:
+                        10
   -v, --verbose         Be more verbose (can be repeated for more detail)
+
+Examples:
+  git outlier                            # analyze last 12 months (if installed as git add-on)
+  git-outlier                            # same as above, direct invocation
+  git outlier --since="6 months ago"     # analyze last 6 months  
+  git outlier --since="2023-01-01" --until="2023-12-31"  # specific date range
+  git outlier -l python -l javascript    # analyze only Python and JavaScript
+  git outlier --metric=NLOC              # use lines of code instead of cyclomatic complexity
+
+For more information, see: https://github.com/BjrnJhsn/git-outlier
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -4,72 +4,106 @@
 ![example workflow](https://github.com/BjrnJhsn/git-outlier/actions/workflows/python-app.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/git-outlier.svg)](https://badge.fury.io/py/git-outlier)
 
+**Find refactoring candidates by analyzing git history and code complexity.**
 
-Data-driven screening to find source code that need refactoring.
+A git add-on that identifies source code files most likely to benefit from refactoring by combining git commit history (churn) with code complexity metrics.
 
-Still under development and not yet ready to be used.
+## How It Works
 
-## Introduction
-Run git-outlier to find source code files that may benefit from refactoring.
-git-outlier finds outliers in a source code directory under git version control in three categories: complexity, churn,
-and  combined complexity and churn. The top files are worthy of further investigation. 
+Git-outlier analyzes your codebase to identify refactoring candidates by examining:
 
-The combined complexity and churn outliers are the top candidates for refactoring. The complexity and churn plot
-is divided into four equal zones:
-- Low churn, low complexity. Files in this zone are ok.
-- Low churn, high complexity. Files in this zone are ok.
-- High churn, low complexity. Files in this zone are ok.
-- High churn, high complexity. **Files in this zone are candidates for refactoring.**
+1. **Code Churn**: How frequently files change over time (from git history)
+2. **Code Complexity**: Cyclomatic complexity or lines of code (using [lizard](http://www.lizard.ws/))
+3. **Combined Analysis**: Files that are both complex AND frequently changed
 
-The files in the high churn, high complexity zone are both complex and 
-change often. The source code in these files will probably be easier to extend and maintain if they are refactored.
+### Analysis Categories
 
-The source code is analyzed per file, so this requires your project to contain multiple source code files 
-with logic entities in separate files to make sense.
+Git-outlier provides three types of analysis:
 
-There are different metrics of complexity available. Choose the one that makes most sense for you or try both. Files
-that are outliers regardless of chosen complexity metrics are top candidates for refactoring.
+- **Complexity Outliers**: Files with the highest complexity scores
+- **Churn Outliers**: Files that change most frequently  
+- **Combined Outliers**: Files with both high complexity and high churn ⭐ **Prime refactoring candidates**
+
+### The Four Zones
+
+The complexity vs. churn plot divides files into four zones:
+
+- **Low churn, low complexity** → ✅ Healthy code
+- **Low churn, high complexity** → ⚠️ Complex but stable  
+- **High churn, low complexity** → ⚠️ Simple but frequently changing
+- **High churn, high complexity** → 🚨 **Refactoring candidates**
+
+Files in the high churn, high complexity zone change frequently AND are complex, making them harder to maintain and more error-prone.
 
 ## Installation
 
-The latest release should be available via PyPI.
-```
+Install from PyPI to use as a git add-on:
+```bash
 [sudo] pip install git-outlier
 ```
 
+Once installed, the tool is available as `git outlier` (note the space) when run from within a git repository. You can also invoke it directly as `git-outlier` (with hyphen) from anywhere.
+
 ## Usage
 
-If installed as a package, it should be directly available in git as
+Once installed, git-outlier can be used as a git add-on:
+```bash
+git outlier                                # analyze last 12 months
+git outlier --since="6 months ago"        # analyze last 6 months
+git outlier --since="2023-01-01" --until="2023-12-31"  # specific date range
 ```
-git outlier
-```
-and use the same options as the python script.
 
-The python script can be run with the following options.
+Or directly as a Python script:
+```bash
+git-outlier --since="1 month ago" -l python javascript
 ```
-usage: git_outlier.py [-h] [--languages LANGUAGES] [--metric METRIC] [--span SPAN] [--top TOP] [-v] [path]
 
-Analyze a source directory that uses git as version handling system. The source files are analyzed for different type of 
-outliers and these outliers can be good candidates for refactoring to increase maintainability. The source files are 
-ranked in falling order after churn, complexity, and combined churn and complexity.
+### Command Options
+
+```
+usage: git outlier [-h] [--languages LANGUAGES] [--metric METRIC] [--since SINCE] [--until UNTIL] [--top TOP] [-v] [path]
+
+Find refactoring candidates by analyzing git history and code complexity.
 
 positional arguments:
-  path                  The path to the source directory to be analyzed. Will default to current directory if not present.
+  path                  Path to git repository to analyze. Default: current directory
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   --languages LANGUAGES, -l LANGUAGES
-                        List the programming languages you want to analyze. If left empty, it'll search for all 
-                        recognized languages. Example: 'outlier -l cpp -l python' searches for C++ and Python code. The
-                        available languages are: c, cpp, csharp, fortran, go, java, javascript, lua, objective-c, php, 
+                        Only analyze specified languages (can be repeated). Default: all supported languages. 
+                        Available: c, cpp, csharp, fortran, go, java, javascript, lua, objective-c, php, 
                         python, ruby, rust, scala, swift, typescript
   --metric METRIC, -m METRIC
-                        Choose the complexity metric you would like to base the results on. Either cyclomatic complexity
-                         'CCN' or lines of code without comments 'NLOC'. If not specified, the default is 'CCN'.
-  --span SPAN, -s SPAN  The number (integer) of months the analysis will look at. Default is 12 months.
-  --top TOP, -t TOP     The number (integer) of outliers to show. Note that for the combined churn and complexity 
-                        outliers, there is no maximum. Default is 10.
-  -v, --verbose         Show analysis details and debug info.
+                        Complexity metric to use: CCN (cyclomatic complexity) or NLOC (lines of code). Default: CCN
+  --since SINCE         Show commits more recent than specific date. 
+                        Accepts: '2023-01-01', '6 months ago', 'last week'. Default: 12 months ago
+  --until UNTIL         Show commits older than specific date. 
+                        Accepts: '2023-12-31', '1 month ago', 'yesterday'. Default: today
+  --top TOP, -t TOP     Limit output to top N outliers per category. Default: 10
+  -v, --verbose         Be more verbose (can be repeated for more detail)
+```
+
+### Examples
+
+```bash
+# Basic usage - analyze last 12 months
+git outlier
+
+# Analyze specific time period
+git outlier --since="3 months ago" --until="1 week ago"
+
+# Focus on specific languages
+git outlier -l python -l javascript -l typescript
+
+# Use lines of code instead of cyclomatic complexity
+git outlier --metric=NLOC
+
+# Show more results and be verbose
+git outlier --top=20 -v
+
+# Analyze specific directory
+git outlier /path/to/project
 ```
 
 ## Supported languages

--- a/git_outlier/git_outlier.py
+++ b/git_outlier/git_outlier.py
@@ -12,7 +12,9 @@ from typing import Dict, List, Tuple, Union, Any, Optional, Sequence
 import lizard
 
 
-def get_git_log_in_current_directory(start_date: str, end_date: Optional[str] = None) -> str:
+def get_git_log_in_current_directory(
+    start_date: str, end_date: Optional[str] = None
+) -> str:
     pipe = subprocess.PIPE
 
     git_command = [
@@ -23,7 +25,7 @@ def get_git_log_in_current_directory(start_date: str, end_date: Optional[str] = 
         f"--since={start_date}",
         "--pretty=",
     ]
-    
+
     # Add --until parameter if end_date is provided
     if end_date:
         git_command.insert(-1, f"--until={end_date}")
@@ -348,7 +350,10 @@ def print_churn_outliers(
 
 
 def get_git_and_complexity_data(
-    endings: List[str], complexity_metric: str, start_date: str, end_date: Optional[str] = None
+    endings: List[str],
+    complexity_metric: str,
+    start_date: str,
+    end_date: Optional[str] = None,
 ) -> Tuple[Dict[str, int], Dict[str, int], List[str]]:
     all_of_it = get_git_log_in_current_directory(start_date, end_date)
     print("Retrieving git log...")
@@ -414,7 +419,7 @@ def parse_arguments(incoming: List[str]) -> Any:
   git outlier --metric=NLOC              # use lines of code instead of cyclomatic complexity
 
 For more information, see: https://github.com/BjrnJhsn/git-outlier""",
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     supported_languages = get_supported_languages()
     supported_languages_list = [*supported_languages]
@@ -542,10 +547,10 @@ def parse_git_date(date_str: Optional[str], default_months_ago: int = 0) -> str:
         else:
             start = date.today() + relativedelta(months=-default_months_ago)
             return str(start)
-    
+
     # Handle relative dates like "6 months ago", "last week", etc.
     date_str = date_str.strip().lower()
-    
+
     # Common git-style relative dates
     if "months ago" in date_str or "month ago" in date_str:
         try:
@@ -579,7 +584,7 @@ def parse_git_date(date_str: Optional[str], default_months_ago: int = 0) -> str:
         return str(start)
     elif date_str in ["today"]:
         return str(date.today())
-    
+
     # Try to parse as absolute date using dateutil
     try:
         parsed_date = parse_date(date_str)
@@ -588,14 +593,16 @@ def parse_git_date(date_str: Optional[str], default_months_ago: int = 0) -> str:
         raise ValueError(f"Unable to parse date '{date_str}': {e}")
 
 
-def get_date_range(since: Optional[str], until: Optional[str]) -> Tuple[str, Optional[str]]:
+def get_date_range(
+    since: Optional[str], until: Optional[str]
+) -> Tuple[str, Optional[str]]:
     """Get the date range for git log analysis, handling both --since and --until"""
     # If no since specified, default to 12 months ago
     start_date = parse_git_date(since, default_months_ago=12)
-    
+
     # Parse until date if provided
     end_date = parse_git_date(until, default_months_ago=0) if until else None
-    
+
     return start_date, end_date
 
 

--- a/test/test_date_parameters.py
+++ b/test/test_date_parameters.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for new --since and --until date parameters.
+Tests the parsing and validation of git-style date expressions.
+"""
+
+import pytest
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+from git_outlier.git_outlier import (
+    parse_git_date,
+    get_date_range,
+    parse_arguments,
+)
+
+
+def test_parse_git_date_none_with_default():
+    """Test parse_git_date with None and default months ago"""
+    # None with 12 months ago
+    result = parse_git_date(None, default_months_ago=12)
+    expected = str(date.today() + relativedelta(months=-12))
+    assert result == expected
+    
+    # None with 0 months ago (today)
+    result = parse_git_date(None, default_months_ago=0)
+    expected = str(date.today())
+    assert result == expected
+
+
+def test_parse_git_date_relative_months():
+    """Test parsing relative date strings with months"""
+    result = parse_git_date("6 months ago")
+    expected = str(date.today() + relativedelta(months=-6))
+    assert result == expected
+    
+    result = parse_git_date("1 months ago")
+    expected = str(date.today() + relativedelta(months=-1))
+    assert result == expected
+
+
+def test_parse_git_date_relative_weeks():
+    """Test parsing relative date strings with weeks"""
+    result = parse_git_date("2 weeks ago")
+    expected = str(date.today() + relativedelta(weeks=-2))
+    assert result == expected
+    
+    result = parse_git_date("last week")
+    expected = str(date.today() + relativedelta(weeks=-1))
+    assert result == expected
+
+
+def test_parse_git_date_relative_days():
+    """Test parsing relative date strings with days"""
+    result = parse_git_date("5 days ago")
+    expected = str(date.today() + relativedelta(days=-5))
+    assert result == expected
+    
+    result = parse_git_date("yesterday")
+    expected = str(date.today() + relativedelta(days=-1))
+    assert result == expected
+
+
+def test_parse_git_date_named_relatives():
+    """Test parsing named relative dates"""
+    result = parse_git_date("today")
+    expected = str(date.today())
+    assert result == expected
+    
+    result = parse_git_date("last month")
+    expected = str(date.today() + relativedelta(months=-1))
+    assert result == expected
+
+
+def test_parse_git_date_absolute_dates():
+    """Test parsing absolute date strings"""
+    result = parse_git_date("2023-01-01")
+    assert result == "2023-01-01"
+    
+    result = parse_git_date("2023-12-31")
+    assert result == "2023-12-31"
+    
+    # Test various date formats that dateutil can parse
+    result = parse_git_date("Jan 1, 2023")
+    assert "2023-01-01" in result
+    
+    result = parse_git_date("2023/06/15")
+    assert "2023-06-15" in result
+
+
+def test_parse_git_date_case_insensitive():
+    """Test that date parsing is case insensitive"""
+    result1 = parse_git_date("6 MONTHS AGO")
+    result2 = parse_git_date("6 months ago")
+    assert result1 == result2
+    
+    result1 = parse_git_date("YESTERDAY")
+    result2 = parse_git_date("yesterday")
+    assert result1 == result2
+
+
+def test_parse_git_date_invalid():
+    """Test parsing invalid date strings"""
+    with pytest.raises(ValueError):
+        parse_git_date("invalid date string")
+    
+    with pytest.raises(ValueError):
+        parse_git_date("not a date")
+    
+    # Malformed relative dates should fallback to dateutil and fail
+    with pytest.raises(ValueError):
+        parse_git_date("abc months ago")
+
+
+def test_get_date_range_both_none():
+    """Test get_date_range with both parameters None"""
+    start_date, end_date = get_date_range(None, None)
+    
+    expected_start = str(date.today() + relativedelta(months=-12))
+    assert start_date == expected_start
+    assert end_date is None
+
+
+def test_get_date_range_since_only():
+    """Test get_date_range with only since parameter"""
+    start_date, end_date = get_date_range("6 months ago", None)
+    
+    expected_start = str(date.today() + relativedelta(months=-6))
+    assert start_date == expected_start
+    assert end_date is None
+
+
+def test_get_date_range_until_only():
+    """Test get_date_range with only until parameter"""
+    start_date, end_date = get_date_range(None, "yesterday")
+    
+    expected_start = str(date.today() + relativedelta(months=-12))
+    expected_end = str(date.today() + relativedelta(days=-1))
+    assert start_date == expected_start
+    assert end_date == expected_end
+
+
+def test_get_date_range_both_parameters():
+    """Test get_date_range with both since and until"""
+    start_date, end_date = get_date_range("1 month ago", "yesterday")
+    
+    expected_start = str(date.today() + relativedelta(months=-1))
+    expected_end = str(date.today() + relativedelta(days=-1))
+    assert start_date == expected_start
+    assert end_date == expected_end
+
+
+def test_argument_parsing_since_until():
+    """Test argument parsing with new --since and --until parameters"""
+    # Test with --since only
+    args = parse_arguments(["--since", "6 months ago", "."])
+    assert args.since == "6 months ago"
+    assert args.until is None
+    
+    # Test with --until only
+    args = parse_arguments(["--until", "yesterday", "."])
+    assert args.since is None
+    assert args.until == "yesterday"
+    
+    # Test with both parameters
+    args = parse_arguments(["--since", "1 month ago", "--until", "yesterday", "."])
+    assert args.since == "1 month ago"
+    assert args.until == "yesterday"
+    
+    # Test with neither (defaults)
+    args = parse_arguments(["."])
+    assert args.since is None
+    assert args.until is None
+
+
+def test_argument_parsing_date_validation():
+    """Test that argument parsing validates date parameters"""
+    # Valid dates should not raise error
+    args = parse_arguments(["--since", "2023-01-01", "."])
+    assert args.since == "2023-01-01"
+    
+    # Invalid dates should raise error
+    with pytest.raises(SystemExit):
+        parse_arguments(["--since", "invalid date", "."])
+    
+    with pytest.raises(SystemExit):
+        parse_arguments(["--until", "not a date", "."])
+
+
+def test_edge_cases_whitespace():
+    """Test parsing with extra whitespace"""
+    result = parse_git_date("  6 months ago  ")
+    expected = str(date.today() + relativedelta(months=-6))
+    assert result == expected
+    
+    result = parse_git_date("  2023-01-01  ")
+    assert result == "2023-01-01"
+
+
+def test_multiple_formats_same_date():
+    """Test that different formats for the same date produce same result"""
+    # These should all parse to the same date
+    date_strings = [
+        "2023-06-15",
+        "June 15, 2023",
+        "2023/06/15",
+        "15-06-2023",
+    ]
+    
+    results = [parse_git_date(ds) for ds in date_strings]
+    
+    # All should contain the same date (allowing for different string formats)
+    for result in results:
+        assert "2023" in result
+        assert "06" in result or "6" in result
+        assert "15" in result
+
+
+def test_boundary_dates():
+    """Test parsing of boundary dates like beginning/end of year"""
+    result = parse_git_date("2023-01-01")
+    assert result == "2023-01-01"
+    
+    result = parse_git_date("2023-12-31") 
+    assert result == "2023-12-31"
+    
+    # Test leap year
+    result = parse_git_date("2024-02-29")
+    assert result == "2024-02-29"

--- a/test/test_date_parameters.py
+++ b/test/test_date_parameters.py
@@ -20,7 +20,7 @@ def test_parse_git_date_none_with_default():
     result = parse_git_date(None, default_months_ago=12)
     expected = str(date.today() + relativedelta(months=-12))
     assert result == expected
-    
+
     # None with 0 months ago (today)
     result = parse_git_date(None, default_months_ago=0)
     expected = str(date.today())
@@ -32,7 +32,7 @@ def test_parse_git_date_relative_months():
     result = parse_git_date("6 months ago")
     expected = str(date.today() + relativedelta(months=-6))
     assert result == expected
-    
+
     result = parse_git_date("1 months ago")
     expected = str(date.today() + relativedelta(months=-1))
     assert result == expected
@@ -43,7 +43,7 @@ def test_parse_git_date_relative_weeks():
     result = parse_git_date("2 weeks ago")
     expected = str(date.today() + relativedelta(weeks=-2))
     assert result == expected
-    
+
     result = parse_git_date("last week")
     expected = str(date.today() + relativedelta(weeks=-1))
     assert result == expected
@@ -54,7 +54,7 @@ def test_parse_git_date_relative_days():
     result = parse_git_date("5 days ago")
     expected = str(date.today() + relativedelta(days=-5))
     assert result == expected
-    
+
     result = parse_git_date("yesterday")
     expected = str(date.today() + relativedelta(days=-1))
     assert result == expected
@@ -65,7 +65,7 @@ def test_parse_git_date_named_relatives():
     result = parse_git_date("today")
     expected = str(date.today())
     assert result == expected
-    
+
     result = parse_git_date("last month")
     expected = str(date.today() + relativedelta(months=-1))
     assert result == expected
@@ -75,14 +75,14 @@ def test_parse_git_date_absolute_dates():
     """Test parsing absolute date strings"""
     result = parse_git_date("2023-01-01")
     assert result == "2023-01-01"
-    
+
     result = parse_git_date("2023-12-31")
     assert result == "2023-12-31"
-    
+
     # Test various date formats that dateutil can parse
     result = parse_git_date("Jan 1, 2023")
     assert "2023-01-01" in result
-    
+
     result = parse_git_date("2023/06/15")
     assert "2023-06-15" in result
 
@@ -92,7 +92,7 @@ def test_parse_git_date_case_insensitive():
     result1 = parse_git_date("6 MONTHS AGO")
     result2 = parse_git_date("6 months ago")
     assert result1 == result2
-    
+
     result1 = parse_git_date("YESTERDAY")
     result2 = parse_git_date("yesterday")
     assert result1 == result2
@@ -102,10 +102,10 @@ def test_parse_git_date_invalid():
     """Test parsing invalid date strings"""
     with pytest.raises(ValueError):
         parse_git_date("invalid date string")
-    
+
     with pytest.raises(ValueError):
         parse_git_date("not a date")
-    
+
     # Malformed relative dates should fallback to dateutil and fail
     with pytest.raises(ValueError):
         parse_git_date("abc months ago")
@@ -114,7 +114,7 @@ def test_parse_git_date_invalid():
 def test_get_date_range_both_none():
     """Test get_date_range with both parameters None"""
     start_date, end_date = get_date_range(None, None)
-    
+
     expected_start = str(date.today() + relativedelta(months=-12))
     assert start_date == expected_start
     assert end_date is None
@@ -123,7 +123,7 @@ def test_get_date_range_both_none():
 def test_get_date_range_since_only():
     """Test get_date_range with only since parameter"""
     start_date, end_date = get_date_range("6 months ago", None)
-    
+
     expected_start = str(date.today() + relativedelta(months=-6))
     assert start_date == expected_start
     assert end_date is None
@@ -132,7 +132,7 @@ def test_get_date_range_since_only():
 def test_get_date_range_until_only():
     """Test get_date_range with only until parameter"""
     start_date, end_date = get_date_range(None, "yesterday")
-    
+
     expected_start = str(date.today() + relativedelta(months=-12))
     expected_end = str(date.today() + relativedelta(days=-1))
     assert start_date == expected_start
@@ -142,7 +142,7 @@ def test_get_date_range_until_only():
 def test_get_date_range_both_parameters():
     """Test get_date_range with both since and until"""
     start_date, end_date = get_date_range("1 month ago", "yesterday")
-    
+
     expected_start = str(date.today() + relativedelta(months=-1))
     expected_end = str(date.today() + relativedelta(days=-1))
     assert start_date == expected_start
@@ -155,17 +155,17 @@ def test_argument_parsing_since_until():
     args = parse_arguments(["--since", "6 months ago", "."])
     assert args.since == "6 months ago"
     assert args.until is None
-    
+
     # Test with --until only
     args = parse_arguments(["--until", "yesterday", "."])
     assert args.since is None
     assert args.until == "yesterday"
-    
+
     # Test with both parameters
     args = parse_arguments(["--since", "1 month ago", "--until", "yesterday", "."])
     assert args.since == "1 month ago"
     assert args.until == "yesterday"
-    
+
     # Test with neither (defaults)
     args = parse_arguments(["."])
     assert args.since is None
@@ -177,11 +177,11 @@ def test_argument_parsing_date_validation():
     # Valid dates should not raise error
     args = parse_arguments(["--since", "2023-01-01", "."])
     assert args.since == "2023-01-01"
-    
+
     # Invalid dates should raise error
     with pytest.raises(SystemExit):
         parse_arguments(["--since", "invalid date", "."])
-    
+
     with pytest.raises(SystemExit):
         parse_arguments(["--until", "not a date", "."])
 
@@ -191,7 +191,7 @@ def test_edge_cases_whitespace():
     result = parse_git_date("  6 months ago  ")
     expected = str(date.today() + relativedelta(months=-6))
     assert result == expected
-    
+
     result = parse_git_date("  2023-01-01  ")
     assert result == "2023-01-01"
 
@@ -205,9 +205,9 @@ def test_multiple_formats_same_date():
         "2023/06/15",
         "15-06-2023",
     ]
-    
+
     results = [parse_git_date(ds) for ds in date_strings]
-    
+
     # All should contain the same date (allowing for different string formats)
     for result in results:
         assert "2023" in result
@@ -219,10 +219,10 @@ def test_boundary_dates():
     """Test parsing of boundary dates like beginning/end of year"""
     result = parse_git_date("2023-01-01")
     assert result == "2023-01-01"
-    
-    result = parse_git_date("2023-12-31") 
+
+    result = parse_git_date("2023-12-31")
     assert result == "2023-12-31"
-    
+
     # Test leap year
     result = parse_git_date("2024-02-29")
     assert result == "2024-02-29"

--- a/test/test_outlier.py
+++ b/test/test_outlier.py
@@ -127,17 +127,20 @@ def test_argument_parser():
     supported_languages = get_supported_languages()
     supported_languages_list = [*supported_languages]
     subject = parse_arguments(".")
-    assert subject.span == 12
+    assert subject.since is None  # Default since replaced span
+    assert subject.until is None  # Default until
     assert subject.languages == supported_languages_list
     assert subject.path == "."
 
     subject = parse_arguments("")
-    assert subject.span == 12
+    assert subject.since is None
+    assert subject.until is None
     assert subject.languages == supported_languages_list
     assert subject.path == "."
 
     subject = parse_arguments([".", "-l", "cpp", "-l", "python"])
-    assert subject.span == 12
+    assert subject.since is None
+    assert subject.until is None
     assert subject.languages == ["cpp", "python"]
     assert subject.path == "."
 


### PR DESCRIPTION
## Summary
- Replace legacy `--span` parameter with git-style `--since` and `--until` parameters  
- Update help text to follow standard git add-on conventions with proper capitalization
- Modernize README documentation with comprehensive examples and improved clarity
- Add comprehensive unit tests for new date parameter functionality

## Changes Made
- **Parameter modernization**: Replaced `--span` with `--since`/`--until` for better git compatibility
- **Date parsing**: Added robust git-style date parsing supporting relative dates ("6 months ago") and absolute dates ("2023-01-01") 
- **Help text improvements**: Updated to follow git conventions with sentence case and better descriptions
- **Documentation updates**: Comprehensive README overhaul with usage examples and clearer explanations
- **Test coverage**: Added 17 unit tests covering date parsing, validation, and edge cases

## Test Plan
- [x] All existing unit tests pass with updated parameters
- [x] New date parameter tests cover relative dates, absolute dates, and validation
- [x] Help text matches actual script output exactly
- [x] GitHub Actions CI passes with all test suites

🤖 Generated with [Claude Code](https://claude.ai/code)