### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python application
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BjrnJhsn/git-outlier/security/code-scanning/1](https://github.com/BjrnJhsn/git-outlier/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the current workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents for testing and linting purposes. If any steps require additional permissions in the future, they can be explicitly added to the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
